### PR TITLE
packet.rs example and rework to remove trait bounds on const generic exprs

### DIFF
--- a/catnip/Cargo.toml
+++ b/catnip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catnip"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -1,16 +1,56 @@
 //! Build a UDP/IP Ethernet packet and get its representation as network bytes
 
-use catnip::ip::IPV4Addr;
-use catnip::MACAddr;
+use catnip::enet::{EthernetHeader, EthernetFrame, EthernetPacket, EtherType};
+use catnip::ip::{IPV4Addr, IPV4Header, DSCP};
+use catnip::udp::{UDPHeader, UDPPacket};
+use catnip::{Data, MACAddr};
+extern crate std; // To show debugging output
+
 pub fn main() -> () {
     // Some made-up addresses
     // MAC address in locally-administered address range
     // IP addresses in local network range
-    let src_macaddr: MACAddr = MACAddr { value: [0x02, 0x01, 0x02, 0x03, 0x04, 0x05] };
-    let src_ipaddr: IPV4Addr = IPV4Addr { value: [10, 0, 0, 1] };
-    let dst_ipaddr: IPV4Addr = IPV4Addr { value: [10, 0, 0, 2] };
+    // Ports are arbitrary
+    let src_macaddr: MACAddr = MACAddr {
+        value: [0x02, 0x01, 0x02, 0x03, 0x04, 0x05],
+    };
+    let dst_macaddr = None;
+    let src_port: u16 = 8123;
+    let dst_port: u16 = 8123;
+    let src_ipaddr: IPV4Addr = IPV4Addr {
+        value: [10, 0, 0, 1],
+    };
+    let dst_ipaddr: IPV4Addr = IPV4Addr {
+        value: [10, 0, 0, 2],
+    };
 
-    // Some made-up data
-    
+    // Some made-up data with two 32-bit words' worth of bytes
+    let data: Data<2> = Data {
+        value: [0, 1, 2, 3, 4, 5, 6, 7],
+    };
 
+    // Build IP header with no Options section
+    // Header length is populated in new()
+    // Total length is populated by UDPPacket.finalize()
+    let ipheader: IPV4Header<0> = IPV4Header::new()
+        .src_ipaddr(src_ipaddr)
+        .dst_ipaddr(dst_ipaddr)
+        .dscp(DSCP::Realtime);
+
+    // Build UDP header
+    let udpheader: UDPHeader = UDPHeader::new(src_port, dst_port);
+
+    // Build UDP packet with 0 words of IP options and 2 words of data
+    let udppacket: UDPPacket<0, 2> = UDPPacket {
+        ip_header: ipheader,
+        udp_header: udpheader,
+        udp_data: data,
+    }
+    .finalize();  // Populate packet length fields for both IP and UDP headers
+
+    // Build Ethernet frame header
+    let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
+
+    // Build Ethernet frame
+    // let enetframe: EthernetFrame<>
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -1,0 +1,16 @@
+//! Build a UDP/IP Ethernet packet and get its representation as network bytes
+
+use catnip::ip::IPV4Addr;
+use catnip::MACAddr;
+pub fn main() -> () {
+    // Some made-up addresses
+    // MAC address in locally-administered address range
+    // IP addresses in local network range
+    let src_macaddr: MACAddr = MACAddr { value: [0x02, 0x01, 0x02, 0x03, 0x04, 0x05] };
+    let src_ipaddr: IPV4Addr = IPV4Addr { value: [10, 0, 0, 1] };
+    let dst_ipaddr: IPV4Addr = IPV4Addr { value: [10, 0, 0, 2] };
+
+    // Some made-up data
+    
+
+}

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -1,6 +1,6 @@
 //! Build a UDP/IP Ethernet packet and get its representation as network bytes
 
-use catnip::enet::{EtherType, EthernetFrame, EthernetHeader, EthernetPacket};
+use catnip::enet::{EtherType, EthernetFrameUDP, EthernetHeader, EthernetPacketUDP};
 use catnip::ip::{IPV4Addr, IPV4Header, DSCP};
 use catnip::udp::{UDPHeader, UDPPacket};
 use catnip::{Data, MACAddr};
@@ -52,11 +52,13 @@ fn main() -> () {
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
 
     // Build Ethernet frame
-    let enetframe = EthernetFrame::new(enetheader, udppacket.to_be_bytes());
+    // Unfortunately the payload has to be reduced to bytes here until const generic expr trait bounds work
+    let enetframe = EthernetFrameUDP::new(enetheader, udppacket);
+    println!("{:?}", enetframe.lengths());
     println!("{:?}", enetframe.to_be_bytes());
 
     // Build Ethernet packet
-    let enetpacket = EthernetPacket::new(enetframe);
+    let enetpacket = EthernetPacketUDP::new(enetframe);
     println!("{:?}", &enetpacket);
     println!("{:?}", enetpacket.to_be_bytes());
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -51,10 +51,9 @@ fn main() -> () {
     // Build Ethernet frame header
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
 
-    let ipheader_bytes = udppacket.ip_header.value;
-    // let ipheader_len = ipheader_bytes.len();
-
+    // let ipheader_bytes = udppacket.ip_header.to_be_bytes();
     let udpheader_bytes = udpheader.to_be_bytes();
+    // let data_bytes = data.to_be_bytes();
     // println!("{:?}", bytes);
 
     // Build Ethernet frame

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -12,7 +12,7 @@ fn main() -> () {
     // IP addresses in local network range
     // Ports are arbitrary
     let src_macaddr: MACAddr = MACAddr {
-        value: [0x02, 0x01, 0x02, 0x03, 0x04, 0x05],
+        value: [0x02, 0xAF, 0xFF, 0x1A, 0xE5, 0x3C],
     };
     let dst_macaddr = None;
     let src_port: u16 = 8123;
@@ -28,6 +28,8 @@ fn main() -> () {
     let data: Data<2> = Data {
         value: [0, 1, 2, 3, 4, 5, 6, 7],
     };
+    println!("{:?}", &data);
+    println!("{:?}\n", &data.to_be_bytes());
 
     // Build IP header with no Options section
     // Header length is populated in new()
@@ -37,9 +39,13 @@ fn main() -> () {
         .dst_ipaddr(dst_ipaddr)
         .dscp(DSCP::Realtime)
         .finalize();
+    println!("{:?}", &ipheader);
+    println!("{:?}\n", &ipheader.to_be_bytes());
 
     // Build UDP header
     let udpheader: UDPHeader = UDPHeader::new(src_port, dst_port);
+    println!("{:?}", &udpheader);
+    println!("{:?}\n", &udpheader.to_be_bytes());
 
     // Build UDP packet with 0 words of IP options and 2 words of data
     let udppacket: UDPPacket<0, 2> = UDPPacket {
@@ -47,18 +53,22 @@ fn main() -> () {
         udp_header: udpheader,
         udp_data: data,
     }; // Populates packet length fields for both IP and UDP headers
+    println!("{:?}", &udppacket);
+    println!("{:?}\n", &udppacket.to_be_bytes());
 
     // Build Ethernet frame header
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
+    println!("{:?}", &enetheader);
+    println!("{:?}\n", &enetheader.to_be_bytes());
 
     // Build Ethernet frame
-    // Unfortunately the payload has to be reduced to bytes here until const generic expr trait bounds work
+    // Unfortunately these can't be generic until const generic expr trait bounds work
     let enetframe = EthernetFrameUDP::new(enetheader, udppacket);
-    println!("{:?}", enetframe.lengths());
-    println!("{:?}", enetframe.to_be_bytes());
+    println!("{:?}", &enetframe);
+    println!("{:?}\n", &enetframe.to_be_bytes());
 
     // Build Ethernet packet
     let enetpacket = EthernetPacketUDP::new(enetframe);
     println!("{:?}", &enetpacket);
-    println!("{:?}", enetpacket.to_be_bytes());
+    println!("{:?}\n", &enetpacket.to_be_bytes());
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -52,5 +52,6 @@ fn main() -> () {
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
 
     // Build Ethernet frame
-    // let enetframe = EthernetFrame::new(enetheader, udppacket);
+    let payload = udppacket.to_be_bytes();
+    let enetframe = EthernetFrame::new(enetheader, payload);
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -51,5 +51,5 @@ fn main() -> () {
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
 
     // Build Ethernet frame
-    let enetframe = EthernetFrame::new(enetheader, udppacket.to_be_bytes());
+    // let enetframe = EthernetFrame::new(enetheader, udppacket);
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -3,10 +3,10 @@
 use catnip::enet::{EthernetHeader, EthernetFrame, EthernetPacket, EtherType};
 use catnip::ip::{IPV4Addr, IPV4Header, DSCP};
 use catnip::udp::{UDPHeader, UDPPacket};
-use catnip::{Data, MACAddr};
+use catnip::{Data, MACAddr, Transportable};
 extern crate std; // To show debugging output
 
-pub fn main() -> () {
+fn main() -> () {
     // Some made-up addresses
     // MAC address in locally-administered address range
     // IP addresses in local network range
@@ -51,5 +51,9 @@ pub fn main() -> () {
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
 
     // Build Ethernet frame
-    // let enetframe: EthernetFrame<>
+    const P: usize = UDPPacket::<0, 2>::LENGTH;
+    let enetframe: EthernetFrame<UDPPacket<0, 2>, P> = EthernetFrame {
+        header: enetheader,
+        data: udppacket
+    };
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -50,6 +50,13 @@ fn main() -> () {
     // Build Ethernet frame header
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
 
+    let ipheader_bytes = udppacket.ip_header.value;
+    // let ipheader_len = ipheader_bytes.len();
+
+    let udpheader_bytes = udpheader.to_be_bytes();
+    // println!("{:?}", bytes);
+
+
     // Build Ethernet frame
     // let enetframe = EthernetFrame::new(enetheader, udppacket);
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -3,7 +3,7 @@
 use catnip::enet::{EthernetHeader, EthernetFrame, EthernetPacket, EtherType};
 use catnip::ip::{IPV4Addr, IPV4Header, DSCP};
 use catnip::udp::{UDPHeader, UDPPacket};
-use catnip::{Data, MACAddr, Transportable};
+use catnip::{Data, MACAddr};
 extern crate std; // To show debugging output
 
 fn main() -> () {
@@ -51,9 +51,10 @@ fn main() -> () {
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
 
     // Build Ethernet frame
-    const P: usize = UDPPacket::<0, 2>::LENGTH;
-    let enetframe: EthernetFrame<UDPPacket<0, 2>, P> = EthernetFrame {
-        header: enetheader,
-        data: udppacket
-    };
+    // const P: usize = UDPPacket::<0, 2>::LENGTH;
+    // println!("{:?}", P);
+    // const N: usize = 0;
+    // const M: usize = 2;
+    // const P: usize = 4 * N + 20 + 4 * M + 8;
+    let enetframe = EthernetFrame::new(enetheader, udppacket);
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -51,11 +51,6 @@ fn main() -> () {
     // Build Ethernet frame header
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
 
-    // let ipheader_bytes = udppacket.ip_header.to_be_bytes();
-    let udpheader_bytes = udpheader.to_be_bytes();
-    // let data_bytes = data.to_be_bytes();
-    // println!("{:?}", bytes);
-
     // Build Ethernet frame
     // let enetframe = EthernetFrame::new(enetheader, udppacket);
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -45,8 +45,7 @@ pub fn main() -> () {
         ip_header: ipheader,
         udp_header: udpheader,
         udp_data: data,
-    }
-    .finalize();  // Populate packet length fields for both IP and UDP headers
+    };  // Populates packet length fields for both IP and UDP headers
 
     // Build Ethernet frame header
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -1,6 +1,6 @@
 //! Build a UDP/IP Ethernet packet and get its representation as network bytes
 
-use catnip::enet::{EthernetHeader, EthernetFrame, EthernetPacket, EtherType};
+use catnip::enet::{EtherType, EthernetFrame, EthernetHeader, EthernetPacket};
 use catnip::ip::{IPV4Addr, IPV4Header, DSCP};
 use catnip::udp::{UDPHeader, UDPPacket};
 use catnip::{Data, MACAddr, Transportable};
@@ -35,7 +35,8 @@ fn main() -> () {
     let ipheader: IPV4Header<0> = IPV4Header::new()
         .src_ipaddr(src_ipaddr)
         .dst_ipaddr(dst_ipaddr)
-        .dscp(DSCP::Realtime);
+        .dscp(DSCP::Realtime)
+        .finalize();
 
     // Build UDP header
     let udpheader: UDPHeader = UDPHeader::new(src_port, dst_port);
@@ -45,7 +46,7 @@ fn main() -> () {
         ip_header: ipheader,
         udp_header: udpheader,
         udp_data: data,
-    };  // Populates packet length fields for both IP and UDP headers
+    }; // Populates packet length fields for both IP and UDP headers
 
     // Build Ethernet frame header
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
@@ -55,7 +56,6 @@ fn main() -> () {
 
     let udpheader_bytes = udpheader.to_be_bytes();
     // println!("{:?}", bytes);
-
 
     // Build Ethernet frame
     // let enetframe = EthernetFrame::new(enetheader, udppacket);

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -3,7 +3,7 @@
 use catnip::enet::{EthernetHeader, EthernetFrame, EthernetPacket, EtherType};
 use catnip::ip::{IPV4Addr, IPV4Header, DSCP};
 use catnip::udp::{UDPHeader, UDPPacket};
-use catnip::{Data, MACAddr};
+use catnip::{Data, MACAddr, Transportable};
 extern crate std; // To show debugging output
 
 fn main() -> () {
@@ -51,10 +51,5 @@ fn main() -> () {
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
 
     // Build Ethernet frame
-    // const P: usize = UDPPacket::<0, 2>::LENGTH;
-    // println!("{:?}", P);
-    // const N: usize = 0;
-    // const M: usize = 2;
-    // const P: usize = 4 * N + 20 + 4 * M + 8;
-    let enetframe = EthernetFrame::new(enetheader, udppacket);
+    let enetframe = EthernetFrame::new(enetheader, udppacket.to_be_bytes());
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -3,7 +3,7 @@
 use catnip::enet::{EtherType, EthernetFrame, EthernetHeader, EthernetPacket};
 use catnip::ip::{IPV4Addr, IPV4Header, DSCP};
 use catnip::udp::{UDPHeader, UDPPacket};
-use catnip::{Data, MACAddr, Transportable};
+use catnip::{Data, MACAddr};
 extern crate std; // To show debugging output
 
 fn main() -> () {
@@ -52,6 +52,11 @@ fn main() -> () {
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
 
     // Build Ethernet frame
-    let payload = udppacket.to_be_bytes();
-    let enetframe = EthernetFrame::new(enetheader, payload);
+    let enetframe = EthernetFrame::new(enetheader, udppacket.to_be_bytes());
+    println!("{:?}", enetframe.to_be_bytes());
+
+    // Build Ethernet packet
+    let enetpacket = EthernetPacket::new(enetframe);
+    println!("{:?}", &enetpacket);
+    println!("{:?}", enetpacket.to_be_bytes());
 }

--- a/catnip/src/enet.rs
+++ b/catnip/src/enet.rs
@@ -105,9 +105,9 @@ where
     T: Transportable<P>,
 {
     /// Ethernet frame header
-    header: EthernetHeader,
+    pub header: EthernetHeader,
     /// Ethernet payload (likely some kind of IP packet)
-    data: T,
+    pub data: T,
 }
 
 impl<T, const P: usize> Transportable<{ P + 14 }> for EthernetFrame<T, P>

--- a/catnip/src/enet.rs
+++ b/catnip/src/enet.rs
@@ -100,31 +100,29 @@ impl Transportable<14> for EthernetHeader {
 /// 
 /// P is length of data's byte representation
 #[derive(Clone, Copy, Debug)]
-pub struct EthernetFrame<T, const P: usize>
-where
-    T: Transportable<P>,
+pub struct EthernetFrame<const P: usize>
+
 {
     /// Ethernet frame header
     pub header: EthernetHeader,
     /// Ethernet payload (likely some kind of IP packet)
-    pub data: T,
+    pub payload: [u8; P],
 }
 
-impl<T, const P: usize> EthernetFrame<T, P> where T: Transportable<P> {
+impl<const P: usize> EthernetFrame<P> {
     /// Generate new, complete frame from components
-    pub fn new(header: EthernetHeader, data: T) -> Self {
-        let enetframe: EthernetFrame<T, P> = EthernetFrame {
+    pub fn new(header: EthernetHeader, payload: [u8; P]) -> Self {
+        let enetframe: EthernetFrame<P> = EthernetFrame {
             header: header,
-            data: data
+            payload: payload
         };
 
         enetframe
     }
 }
 
-impl<T, const P: usize> Transportable<{ P + 14 }> for EthernetFrame<T, P>
-where
-    T: Transportable<P>,
+impl<const P: usize> Transportable<{ P + 14 }> for EthernetFrame<P>
+
 {
     /// Pack into big-endian (network) byte array
     fn to_be_bytes(&self) -> [u8; P + 14] {
@@ -134,7 +132,7 @@ where
             bytes[i] = v;
             i = i + 1;
         }
-        for v in self.data.to_be_bytes() {
+        for v in self.payload {
             bytes[i] = v;
             i = i + 1;
         }
@@ -145,16 +143,14 @@ where
 
 /// Ethernet II packet (including preamble, start-frame delimiter, and interpacket gap)
 #[derive(Clone, Copy, Debug)]
-pub struct EthernetPacket<T, const P: usize>
-where
-    T: Transportable<P>,
+pub struct EthernetPacket<const P: usize>
+
 {
-    frame: EthernetFrame<T, P>,
+    frame: EthernetFrame<P>,
 }
 
-impl<T, const P: usize> Transportable<{ P + 14 + 24 }> for EthernetPacket<T, P>
-where
-    T: Transportable<P>,
+impl<const P: usize> Transportable<{ P + 14 + 24 }> for EthernetPacket<P>
+
 {
     fn to_be_bytes(&self) -> [u8; P + 14 + 24] {
         // Initialize output

--- a/catnip/src/enet.rs
+++ b/catnip/src/enet.rs
@@ -100,20 +100,18 @@ impl Transportable<14> for EthernetHeader {
 /// 
 /// P is length of data's byte representation
 #[derive(Clone, Copy, Debug)]
-pub struct EthernetFrame<T, const P: usize>
-where
-    T: Transportable<P>,
+pub struct EthernetFrame<const P: usize>
 {
     /// Ethernet frame header
     pub header: EthernetHeader,
     /// Ethernet payload (likely some kind of IP packet)
-    pub data: T,
+    pub data: [u8; P],
 }
 
-impl<T, const P: usize> EthernetFrame<T, P> where T: Transportable<P> {
+impl<const P: usize> EthernetFrame<P> {
     /// Generate new, complete frame from components
-    pub fn new(header: EthernetHeader, data: T) -> Self {
-        let enetframe: EthernetFrame<T, P> = EthernetFrame {
+    pub fn new(header: EthernetHeader, data: [u8; P]) -> Self {
+        let enetframe: EthernetFrame<P> = EthernetFrame {
             header: header,
             data: data
         };
@@ -122,9 +120,7 @@ impl<T, const P: usize> EthernetFrame<T, P> where T: Transportable<P> {
     }
 }
 
-impl<T, const P: usize> Transportable<{ P + 14 }> for EthernetFrame<T, P>
-where
-    T: Transportable<P>,
+impl<const P: usize> Transportable<{ P + 14 }> for EthernetFrame<P>
 {
     /// Pack into big-endian (network) byte array
     fn to_be_bytes(&self) -> [u8; P + 14] {
@@ -134,7 +130,7 @@ where
             bytes[i] = v;
             i = i + 1;
         }
-        for v in self.data.to_be_bytes() {
+        for v in self.data {
             bytes[i] = v;
             i = i + 1;
         }
@@ -145,16 +141,12 @@ where
 
 /// Ethernet II packet (including preamble, start-frame delimiter, and interpacket gap)
 #[derive(Clone, Copy, Debug)]
-pub struct EthernetPacket<T, const P: usize>
-where
-    T: Transportable<P>,
+pub struct EthernetPacket<const P: usize>
 {
-    frame: EthernetFrame<T, P>,
+    frame: EthernetFrame<P>,
 }
 
-impl<T, const P: usize> Transportable<{ P + 14 + 24 }> for EthernetPacket<T, P>
-where
-    T: Transportable<P>,
+impl<const P: usize> Transportable<{ P + 14 + 24 }> for EthernetPacket<P>
 {
     fn to_be_bytes(&self) -> [u8; P + 14 + 24] {
         // Initialize output

--- a/catnip/src/enet.rs
+++ b/catnip/src/enet.rs
@@ -97,7 +97,7 @@ impl EthernetHeader {
     }
 
     /// Pack into big-endian (network) byte array
-    fn to_be_bytes(&self) -> [u8; 14] {
+    pub fn to_be_bytes(&self) -> [u8; 14] {
         self.value
     }
 }
@@ -139,15 +139,6 @@ where
     /// Get length of byte representation
     pub fn len(&self) -> usize {
         Self::LENGTH
-    }
-
-    ///asdf
-    pub fn lengths(&self) -> (usize, usize, usize) {
-        (
-            4 * N + 20 + 4 * M + 14,
-            self.header.value.len(),
-            self.payload.to_be_bytes().len(),
-        )
     }
 
     /// Pack into big-endian (network) byte array

--- a/catnip/src/enet.rs
+++ b/catnip/src/enet.rs
@@ -110,6 +110,18 @@ where
     pub data: T,
 }
 
+impl<T, const P: usize> EthernetFrame<T, P> where T: Transportable<P> {
+    /// Generate new, complete frame from components
+    pub fn new(header: EthernetHeader, data: T) -> Self {
+        let enetframe: EthernetFrame<T, P> = EthernetFrame {
+            header: header,
+            data: data
+        };
+
+        enetframe
+    }
+}
+
 impl<T, const P: usize> Transportable<{ P + 14 }> for EthernetFrame<T, P>
 where
     T: Transportable<P>,

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -38,7 +38,7 @@ use crate::{Transportable, calc_ip_checksum};
 ///
 /// N is number of 32-bit words to reserve for the Options section
 #[derive(Clone, Copy, Debug)]
-pub struct IPV4Header<'a, const N: usize>
+pub struct IPV4Header<const N: usize>
 where
     [u8; 4 * N + 20]:,
 {
@@ -46,14 +46,14 @@ where
     pub value: [u8; 4 * N + 20],
 }
 
-impl<'a, const N: usize> IPV4Header<'a, N>
+impl<const N: usize> IPV4Header<N>
 where
     [u8; 4 * N + 20]:,
     [u16; 2 * N + 10]:,
     [u32; N + 5]:,
 {
     /// Start from some sensible defaults
-    pub fn new() -> IPV4Header<'a, N> {
+    pub fn new() -> Self {
         // Clear any existing values in the provided container
         let content: [u8; 4 * N + 20] = [0_u8; 4 * N + 20];
 
@@ -193,7 +193,7 @@ where
     }
 
     /// Make from 16-bit words
-    pub fn from_16bit_words<'b, const M: usize>(header16: &[u16; 2 * M + 10]) -> IPV4Header<'b, M>
+    pub fn from_16bit_words<'b, const M: usize>(header16: &[u16; 2 * M + 10]) -> IPV4Header<M>
     where
         [u16; 2 * M + 10]:,
         [u8; 4 * M + 20]:,
@@ -212,7 +212,7 @@ where
     }
 
     /// Make from 16-bit words
-    pub fn from_32bit_words<'b, const M: usize>(header32: &[u32; M + 5]) -> IPV4Header<'b, M>
+    pub fn from_32bit_words<'b, const M: usize>(header32: &[u32; M + 5]) -> IPV4Header<M>
     where
         [u32; M + 5]:,
         [u8; 4 * M + 20]:,
@@ -232,12 +232,12 @@ where
     }
 }
 
-impl<'a, const N: usize> Transportable<{ 4 * N + 20 }> for IPV4Header<'_, N>
+impl<'a, const N: usize> Transportable<{ 4 * N + 20 }> for IPV4Header<N>
 where
     [u8; 4 * N + 20]:,
 {
     fn to_be_bytes(&self) -> [u8; 4 * N + 20] {
-        self.value.clone()
+        self.value
     }
 }
 

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -49,8 +49,6 @@ where
 impl<const N: usize> IPV4Header<N>
 where
     [u8; 4 * N + 20]:,
-    [u16; 2 * N + 10]:,
-    [u32; N + 5]:,
 {
     /// Start from some sensible defaults
     pub fn new() -> Self {

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -226,7 +226,16 @@ where
         header
     }
 
-    fn to_be_bytes(&self) -> [u8; 4 * N + 20] {
+    /// Length of byte representation
+    const LENGTH: usize = 4 * N + 20;
+
+    /// Get length of byte representation
+    fn len(&self) -> usize {
+        Self::LENGTH
+    }
+
+    /// Pack into big-endian (network) byte array
+    pub fn to_be_bytes(&self) -> [u8; 4 * N + 20] {
         self.value
     }
 }

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -197,7 +197,6 @@ where
     /// Make from 16-bit words
     pub fn from_16bit_words<const M: usize>(header16: &[u16; 2 * M + 10]) -> IPV4Header<M>
     where
-        [u16; 2 * M + 10]:,
         [u8; 4 * M + 20]:,
     {
         // Convert words to bytes
@@ -216,7 +215,6 @@ where
     /// Make from 16-bit words
     pub fn from_32bit_words<const M: usize>(header32: &[u32; M + 5]) -> IPV4Header<M>
     where
-        [u32; M + 5]:,
         [u8; 4 * M + 20]:,
     {
         // Convert words to bytes
@@ -235,8 +233,6 @@ where
 }
 
 impl<'a, const N: usize> Transportable<{ 4 * N + 20 }> for IPV4Header<N>
-where
-    [u8; 4 * N + 20]:,
 {
     fn to_be_bytes(&self) -> [u8; 4 * N + 20] {
         self.value

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -177,7 +177,7 @@ where
     /// Set source IP address
     pub fn src_ipaddr(mut self, v: IPV4Addr) -> Self {
         for i in 0..4_usize {
-            self.value[12 + i] = v.addr[i];
+            self.value[12 + i] = v.value[i];
         }
 
         self
@@ -186,7 +186,7 @@ where
     /// Set destination IP address
     pub fn dst_ipaddr(mut self, v: IPV4Addr) -> Self {
         for i in 0..4_usize {
-            self.value[16 + i] = v.addr[i];
+            self.value[16 + i] = v.value[i];
         }
 
         self
@@ -244,7 +244,8 @@ where
 /// IPV4 Address as bytes
 #[derive(Clone, Copy, Debug)]
 pub struct IPV4Addr {
-    addr: [u8; 4],
+    /// 4-byte IP address
+    pub value: [u8; 4],
 }
 
 /// Common choices of transport-layer protocols

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -1,6 +1,6 @@
 //! Internet Protocol message header construction
 
-use crate::{calc_ip_checksum, Transportable};
+use crate::{calc_ip_checksum};
 
 /// IPV4 header per IETF-RFC-791
 ///

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -52,11 +52,8 @@ where
 {
     /// Start from some sensible defaults
     pub fn new() -> Self {
-        // Clear any existing values in the provided container
-        let content: [u8; 4 * N + 20] = [0_u8; 4 * N + 20];
-
         // Start a blank header and apply some sensible defaults
-        let header = IPV4Header { value: content }
+        let header = IPV4Header { value: [0_u8; 4 * N + 20] }
             .version(Version::V4)
             .header_length({ 5 + N } as u8)
             .dscp(DSCP::Standard)
@@ -228,14 +225,18 @@ where
 
         header
     }
-}
 
-impl<'a, const N: usize> Transportable<{ 4 * N + 20 }> for IPV4Header<N>
-{
     fn to_be_bytes(&self) -> [u8; 4 * N + 20] {
         self.value
     }
 }
+
+// impl<'a, const N: usize> Transportable<{ 4 * N + 20 }> for IPV4Header<N>
+// {
+//     fn to_be_bytes(&self) -> [u8; 4 * N + 20] {
+//         self.value
+//     }
+// }
 
 /// IPV4 Address as bytes
 #[derive(Clone, Copy, Debug)]

--- a/catnip/src/lib.rs
+++ b/catnip/src/lib.rs
@@ -25,10 +25,18 @@ pub struct MACAddr {
     pub value: [u8; 6],
 }
 
-// /// Ethernet data must be a multiple of 4 bytes (32-bit words)
-// pub struct Data<const Q: usize> {
+/// Ethernet data must be a multiple of 4 bytes (32-bit words)
+#[derive(Clone, Copy, Debug)]
+pub struct Data<const Q: usize> where [u8; 4 * Q]:, {
+    /// Byte array of data
+    pub value: [u8; 4 * Q]
+}
 
-// }
+impl<const Q: usize> Transportable<{4 * Q}> for Data<Q> where [u8; 4 * Q]:, {
+    fn to_be_bytes(&self) -> [u8; 4 * Q] {
+        self.value
+    }
+}
 
 /// Calculate IP checksum per IETF-RFC-768
 /// following implementation guide in IETF-RFC-1071 section 4.1

--- a/catnip/src/lib.rs
+++ b/catnip/src/lib.rs
@@ -20,10 +20,15 @@ pub trait Transportable<const N: usize> {
 /// MAC Addresses & methods for converting between common formats
 /// Locally-administered addresses are [0x02, ...], [0x06, ...], [0x0A, ...], [0x0E, ...]
 #[derive(Clone, Copy, Debug)]
-pub struct MACAddress {
+pub struct MACAddr {
     /// Split 24/24 format, Block ID | Device ID
     pub value: [u8; 6],
 }
+
+// /// Ethernet data must be a multiple of 4 bytes (32-bit words)
+// pub struct Data<const Q: usize> {
+
+// }
 
 /// Calculate IP checksum per IETF-RFC-768
 /// following implementation guide in IETF-RFC-1071 section 4.1

--- a/catnip/src/lib.rs
+++ b/catnip/src/lib.rs
@@ -13,8 +13,14 @@ pub mod udp; // Transport layer
 /// All protocols' headers, data, and frames must be able to convert to byte array
 /// in order to be consumed by EMAC/PHY drivers for transmission
 pub trait Transportable<const N: usize> {
+    /// Length of byte representation
+    const LENGTH: usize = N;
     /// Convert to big-endian (network) byte array
     fn to_be_bytes(&self) -> [u8; N];
+    /// Get length of instance's byte representation
+    fn len(&self) -> usize {
+        Self::LENGTH
+    }
 }
 
 /// MAC Addresses & methods for converting between common formats

--- a/catnip/src/lib.rs
+++ b/catnip/src/lib.rs
@@ -15,12 +15,12 @@ pub mod udp; // Transport layer
 pub trait Transportable<const N: usize> {
     /// Length of byte representation
     const LENGTH: usize = N;
-    /// Convert to big-endian (network) byte array
-    fn to_be_bytes(&self) -> [u8; N];
-    /// Get length of instance's byte representation
+    /// Get length of byte representation
     fn len(&self) -> usize {
         Self::LENGTH
     }
+    /// Convert to big-endian (network) byte array
+    fn to_be_bytes(&self) -> [u8; N];
 }
 
 /// MAC Addresses & methods for converting between common formats

--- a/catnip/src/lib.rs
+++ b/catnip/src/lib.rs
@@ -127,7 +127,7 @@ mod tests {
             0x0a63_u16, 0xac10_u16, 0x0a0c_u16, 0x0F00_u16, 0_u16,
         ];
         let mut header: IPV4Header<1> = IPV4Header::<1>::from_16bit_words(&ipheader_16_extended);
-        header = header.header_checksum(); // Apply checksum value
+        header = header.header_checksum().finalize(); // Apply checksum value
         let cyclic_check = calc_ip_checksum(&header.value);
         assert_eq!(cyclic_check, 0_u16);
     }

--- a/catnip/src/lib.rs
+++ b/catnip/src/lib.rs
@@ -11,7 +11,8 @@ pub mod ip; // Internet layer
 pub mod udp; // Transport layer
 
 /// All protocols' headers, data, and frames must be able to convert to byte array
-// /// in order to be consumed by EMAC/PHY drivers for transmission
+/// in order to be consumed by EMAC/PHY drivers for transmission
+/// TODO: bring this impl back in once const generic exprs in trait bounds no longer break the compiler
 // pub trait Transportable<const N: usize> {
 //     /// Length of byte representation
 //     const LENGTH: usize = N;
@@ -31,12 +32,11 @@ pub struct MACAddr {
     pub value: [u8; 6],
 }
 
-/// Ethernet data must be a multiple of 4 bytes (32-bit words)
+/// IP and UDP require their data to be a multiple of 4 bytes (32-bit words)
 #[derive(Clone, Copy, Debug)]
 pub struct Data<const Q: usize> where [u8; 4 * Q]:, {
     /// Byte array of data
     pub value: [u8; 4 * Q]
-
 }
 
 impl<const Q: usize> Data<Q> where [u8; 4 * Q]:,  {

--- a/catnip/src/lib.rs
+++ b/catnip/src/lib.rs
@@ -49,7 +49,7 @@ impl<const Q: usize> Data<Q> where [u8; 4 * Q]:,  {
     }
 
     /// Pack into big-endian (network) byte array
-    fn to_be_bytes(&self) -> [u8; 4 * Q] {
+    pub fn to_be_bytes(&self) -> [u8; 4 * Q] {
         self.value
     }
 }

--- a/catnip/src/lib.rs
+++ b/catnip/src/lib.rs
@@ -11,17 +11,17 @@ pub mod ip; // Internet layer
 pub mod udp; // Transport layer
 
 /// All protocols' headers, data, and frames must be able to convert to byte array
-/// in order to be consumed by EMAC/PHY drivers for transmission
-pub trait Transportable<const N: usize> {
-    /// Length of byte representation
-    const LENGTH: usize = N;
-    /// Get length of byte representation
-    fn len(&self) -> usize {
-        Self::LENGTH
-    }
-    /// Convert to big-endian (network) byte array
-    fn to_be_bytes(&self) -> [u8; N];
-}
+// /// in order to be consumed by EMAC/PHY drivers for transmission
+// pub trait Transportable<const N: usize> {
+//     /// Length of byte representation
+//     const LENGTH: usize = N;
+//     /// Get length of byte representation
+//     fn len(&self) -> usize {
+//         Self::LENGTH
+//     }
+//     /// Convert to big-endian (network) byte array
+//     fn to_be_bytes(&self) -> [u8; N];
+// }
 
 /// MAC Addresses & methods for converting between common formats
 /// Locally-administered addresses are [0x02, ...], [0x06, ...], [0x0A, ...], [0x0E, ...]
@@ -36,9 +36,19 @@ pub struct MACAddr {
 pub struct Data<const Q: usize> where [u8; 4 * Q]:, {
     /// Byte array of data
     pub value: [u8; 4 * Q]
+
 }
 
-impl<const Q: usize> Transportable<{4 * Q}> for Data<Q> where [u8; 4 * Q]:, {
+impl<const Q: usize> Data<Q> where [u8; 4 * Q]:,  {
+    /// Length of byte representation
+    const LENGTH: usize = 4 * Q;
+
+    /// Get length of byte representation
+    fn len(&self) -> usize {
+        Self::LENGTH
+    }
+
+    /// Pack into big-endian (network) byte array
     fn to_be_bytes(&self) -> [u8; 4 * Q] {
         self.value
     }

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -50,21 +50,21 @@ impl Transportable<8> for UDPHeader {
 ///
 /// M is size of UDP Data in 32-bit words
 #[derive(Clone, Copy, Debug)]
-pub struct UDPPacket<'a, const N: usize, const M: usize>
+pub struct UDPPacket<const N: usize, const M: usize>
 where
     [u8; 4 * N + 20]:,
     [u8; 4 * M]:,
 {
     /// IPV4 packet header
-    pub ip_header: IPV4Header<'a, N>,
+    pub ip_header: IPV4Header<N>,
     /// UDP datagram header
     pub udp_header: UDPHeader,
     /// Data to transmit; bytes in some multiple of 32 bit words
     pub udp_data: Data<M>,
 }
 
-impl<'a, const N: usize, const M: usize> Transportable<{ 4 * N + 20 + 4 * M + 8 }>
-    for UDPPacket<'a, N, M>
+impl<const N: usize, const M: usize> Transportable<{ 4 * N + 20 + 4 * M + 8 }>
+    for UDPPacket<N, M>
 where
     [u8; 4 * M]:,
     [u8; 4 * N + 20]:,
@@ -93,7 +93,7 @@ where
     }
 }
 
-impl<'a, const N: usize, const M: usize> UDPPacket<'a, N, M>
+impl<const N: usize, const M: usize> UDPPacket<N, M>
 where
     [u8; 4 * M]:,
     [u8; 4 * N + 20]:,
@@ -109,11 +109,11 @@ where
     ///
     /// M is size of UDP Data in 32-bit words
     pub fn new(
-        ip_header: IPV4Header<'a, N>,
+        ip_header: IPV4Header<N>,
         udp_header: UDPHeader,
         udp_data: Data<M>,
-    ) -> UDPPacket<'_, N, M> {
-        let mut udppacket: UDPPacket<'a, N, M> = UDPPacket::<N, M> {
+    ) -> UDPPacket<N, M> {
+        let mut udppacket: UDPPacket<N, M> = UDPPacket::<N, M> {
             ip_header: ip_header,
             udp_header: udp_header,
             udp_data: udp_data,

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -67,45 +67,36 @@ where
     [u8; 4 * N + 20]:,
     [u8; 4 * N + 20 + 4 * M + 8]:, // Required for Transportable trait
 {
-    /// Set values that require the complete packet (length, checksums)
+    /// Build a UDP packet and populate the components that depend on the combined data
+    /// 
+    /// N is size of IP Options in 32-bit words
     ///
-    /// TODO: use IPV4Header's methods to set its values once the missing bounds error is fixed
-    pub fn finalize(mut self) -> Self {
+    /// M is size of UDP Data in 32-bit words 
+    pub fn new(ip_header: IPV4Header<'a, N>, udp_header: UDPHeader, udp_data: Data<M>) -> UDPPacket<'a, N, M> {
+
+        let mut udppacket: UDPPacket<'a, N, M> = UDPPacket::<N, M> { ip_header: ip_header, udp_header:udp_header, udp_data:udp_data };
+
         // Set IP frame length
-        let ip_length: u16 = self.to_be_bytes().len() as u16;
-        // self.ip_header = self.ip_header.total_length(ip_length);
+        let ip_length: u16 = udppacket.to_be_bytes().len() as u16;
+        // udppacket.ip_header = udppacket.ip_header.total_length(ip_length);
         let bytes: [u8; 2] = ip_length.to_be_bytes();
-        self.ip_header.value[2] = bytes[0];
-        self.ip_header.value[3] = bytes[1];
+        udppacket.ip_header.value[2] = bytes[0];
+        udppacket.ip_header.value[3] = bytes[1];
 
         // Set IP header checksum
-        // Clear old
-        self.ip_header.value[10] = 0;
-        self.ip_header.value[11] = 0;
         // Apply new
-        let checksum = calc_ip_checksum(&self.ip_header.value);
+        let checksum = calc_ip_checksum(&udppacket.ip_header.value);
         let bytes: [u8; 2] = checksum.to_be_bytes();
-        self.ip_header.value[10] = bytes[0];
-        self.ip_header.value[11] = bytes[1];
+        udppacket.ip_header.value[10] = bytes[0];
+        udppacket.ip_header.value[11] = bytes[1];
 
         // Set UDP data length in bytes
-        self.udp_header.value[2] = (self.udp_data.value.len() + 2 * self.udp_header.value.len()) as u16;
+        udppacket.udp_header.value[2] = (udppacket.udp_data.value.len() + 2 * udppacket.udp_header.value.len()) as u16;
 
         // Zero-out UDP checksum because it is redundant with ethernet checksum & prone to overflow
-        // // Set UDP header checksum, summing up the parts of the "pseudoheader"
-        // // See https://en.wikipedia.org/wiki/User_Datagram_Protocol#IPv4_pseudo_header
-        // Clear old
-        self.udp_header.value[3] = 0;
-        // // Apply new
-        // let mut udp_checksum: u16 = 0_u16;
-        // udp_checksum = udp_checksum + calc_checksum(&self.ip_header.value[12..20]); // src, dst ipaddrs
-        // let protocol_bytes: [u8; 2] = (self.ip_header.value[9] as u16).to_be_bytes();
-        // udp_checksum = udp_checksum + calc_checksum(&protocol_bytes); // Protocol with zero-padding
-        // udp_checksum = udp_checksum + calc_checksum(&self.udp_header.to_be_bytes()); // UDP header
-        // udp_checksum = udp_checksum + calc_checksum(&self.udp_data); // The actual data
-        // self.udp_header.value[3] = udp_checksum;
+        udppacket.udp_header.value[3] = 0;
 
-        self
+        udppacket
     }
 }
 

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -63,36 +63,6 @@ where
     pub udp_data: Data<M>,
 }
 
-impl<const N: usize, const M: usize> Transportable<{ 4 * N + 20 + 4 * M + 8 }>
-    for UDPPacket<N, M>
-where
-    [u8; 4 * M]:,
-    [u8; 4 * N + 20]:,
-    [u8; 4 * N + 20 + 4 * M + 8]:,
-{
-
-    /// Pack into big-endian (network) byte array
-    fn to_be_bytes(&self) -> [u8; 4 * N + 20 + 4 * M + 8] {
-        // Pack a byte array with IP header, UDP header, and UDP data
-        let mut bytes = [0_u8; 4 * N + 20 + 4 * M + 8];
-        let mut i = 0;
-        for v in self.ip_header.to_be_bytes() {
-            bytes[i] = v;
-            i = i + 1;
-        }
-        for v in self.udp_header.to_be_bytes() {
-            bytes[i] = v;
-            i = i + 1;
-        }
-        for v in self.udp_data.value {
-            bytes[i] = v;
-            i = i + 1;
-        }
-
-        bytes
-    }
-}
-
 impl<const N: usize, const M: usize> UDPPacket<N, M>
 where
     [u8; 4 * M]:,
@@ -102,6 +72,11 @@ where
 {
     /// Length of byte representation
     pub const LENGTH: usize = 4 * N + 20 + 4 * M + 8;
+
+    /// Length of instance's byte representation
+    pub fn len(&self) -> usize {
+        4 * N + 20 + 4 * M + 8
+    }
 
     /// Build a UDP packet and populate the components that depend on the combined data
     ///
@@ -139,6 +114,27 @@ where
         udppacket.udp_header.value[3] = 0;
 
         udppacket
+    }
+
+    /// Pack into big-endian (network) byte array
+    pub fn to_be_bytes(&self) -> [u8; 4 * N + 20 + 4 * M + 8] {
+        // Pack a byte array with IP header, UDP header, and UDP data
+        let mut bytes = [0_u8; 4 * N + 20 + 4 * M + 8];
+        let mut i = 0;
+        for v in self.ip_header.value {
+            bytes[i] = v;
+            i = i + 1;
+        }
+        for v in self.udp_header.to_be_bytes() {
+            bytes[i] = v;
+            i = i + 1;
+        }
+        for v in self.udp_data.value {
+            bytes[i] = v;
+            i = i + 1;
+        }
+
+        bytes
     }
 }
 

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -1,7 +1,7 @@
 //! User Datagram Protocol
 
 use crate::ip::IPV4Header;
-use crate::{calc_ip_checksum, Data, Transportable};
+use crate::{calc_ip_checksum, Data};
 
 /// UDP datagram header structure like
 ///
@@ -28,11 +28,17 @@ impl UDPHeader {
 
         header
     }
-}
 
-impl Transportable<8> for UDPHeader {
+    /// Length of byte representation
+    const LENGTH: usize = 8;
+
+    /// Get length of byte representation
+    fn len(&self) -> usize {
+        Self::LENGTH
+    }
+
     /// Pack into big-endian (network) byte array
-    fn to_be_bytes(&self) -> [u8; 8] {
+    pub fn to_be_bytes(&self) -> [u8; 8] {
         let mut header_bytes = [0_u8; 8];
         for (i, v) in self.value.iter().enumerate() {
             let bytes: [u8; 2] = v.to_be_bytes();
@@ -43,6 +49,7 @@ impl Transportable<8> for UDPHeader {
         header_bytes
     }
 }
+
 
 /// IP message frame for UDP protocol
 ///
@@ -70,14 +77,6 @@ where
     [u8; 4 * N + 20 + 4 * M + 8]:, // Required for Transportable trait
     // UDPPacket<'a, N, M>: Transportable<{ 4 * N + 20 + 4 * M + 8 }>,
 {
-    /// Length of byte representation
-    pub const LENGTH: usize = 4 * N + 20 + 4 * M + 8;
-
-    /// Length of instance's byte representation
-    pub fn len(&self) -> usize {
-        4 * N + 20 + 4 * M + 8
-    }
-
     /// Build a UDP packet and populate the components that depend on the combined data
     ///
     /// N is size of IP Options in 32-bit words
@@ -114,6 +113,14 @@ where
         udppacket.udp_header.value[3] = 0;
 
         udppacket
+    }
+
+    /// Length of byte representation
+    pub const LENGTH: usize = 4 * N + 20 + 4 * M + 8;
+
+    /// Length of instance's byte representation
+    pub fn len(&self) -> usize {
+        4 * N + 20 + 4 * M + 8
     }
 
     /// Pack into big-endian (network) byte array

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -1,7 +1,7 @@
 //! User Datagram Protocol
 
 use crate::ip::IPV4Header;
-use crate::{calc_ip_checksum, Transportable};
+use crate::{calc_ip_checksum, Transportable, Data};
 
 /// UDP datagram header structure like
 ///
@@ -53,7 +53,7 @@ where
 {
     pub ip_header: IPV4Header<'a, N>,
     pub udp_header: UDPHeader,
-    pub udp_data: [u8; 4 * M],
+    pub udp_data: Data<M>,
 }
 
 impl<'a, const N: usize, const M: usize> UDPPacket<'a, N, M>
@@ -84,7 +84,7 @@ where
         self.ip_header.value[11] = bytes[1];
 
         // Set UDP data length in bytes
-        self.udp_header.value[2] = (self.udp_data.len() + 2 * self.udp_header.value.len()) as u16;
+        self.udp_header.value[2] = (self.udp_data.value.len() + 2 * self.udp_header.value.len()) as u16;
 
         // Zero-out UDP checksum because it is redundant with ethernet checksum & prone to overflow
         // // Set UDP header checksum, summing up the parts of the "pseudoheader"
@@ -124,7 +124,7 @@ where
             bytes[i] = v;
             i = i + 1;
         }
-        for v in self.udp_data {
+        for v in self.udp_data.value {
             bytes[i] = v;
             i = i + 1;
         }

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -161,6 +161,5 @@ mod test {
     //         udp_data: example_data,
     //     };
 
-
     // }
 }

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -13,14 +13,16 @@ use crate::{calc_ip_checksum, Transportable, Data};
 ///
 /// value [3] checksum [u16]
 #[derive(Clone, Copy, Debug)]
-struct UDPHeader {
+pub struct UDPHeader {
     value: [u16; 4],
 }
 
 impl UDPHeader {
-    pub fn new() -> UDPHeader {
-        // Start a blank header
-        let header: UDPHeader = UDPHeader { value: [0_u16; 4] };
+    /// Start a header with src and dst ports populated
+    /// 
+    /// Length and checksum will be populated later
+    pub fn new(src_port: u16, dst_port: u16) -> UDPHeader {
+        let header: UDPHeader = UDPHeader { value: [src_port, dst_port, 0, 0] };
 
         header
     }
@@ -46,13 +48,16 @@ impl Transportable<8> for UDPHeader {
 ///
 /// M is size of UDP Data in 32-bit words
 #[derive(Clone, Copy, Debug)]
-struct UDPPacket<'a, const N: usize, const M: usize>
+pub struct UDPPacket<'a, const N: usize, const M: usize>
 where
     [u8; 4 * N + 20]:,
     [u8; 4 * M]:,
 {
+    /// IPV4 packet header
     pub ip_header: IPV4Header<'a, N>,
+    /// UDP datagram header
     pub udp_header: UDPHeader,
+    /// Data to transmit; bytes in some multiple of 32 bit words
     pub udp_data: Data<M>,
 }
 


### PR DESCRIPTION
* Build packet.rs example walking through buildup of an Ethernet packet for UDP
* Remove Transportable trait because trait bounds on const generic exprs consistently cause compiler errors
* Rework each module to accommodate removal of Transportable