### PR TITLE
Add parsing capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # catnip
 
-A no-std, heapless, minimally-featured UDP/IP stack for bare-metal.
-Intended for high-speed, realtime data acquisition and controls on 
-physically-secured local networks.
+A no-std, panic-never, heapless, minimally-featured UDP/IP stack for bare-metal.
+Intended for high-speed, fixed-time data acquisition and controls on 
+physically-secured local networks. 
+
+This crate currently relies on the nightly channel, and as a result, will break regularly
+until the required features stabilize.
 
 Makes extensive use of const generic expressions to provide flexibility in, 
 and guaranteed correctness of, lengths of headers and data segments without
@@ -11,10 +14,13 @@ dynamic allocation.
 This library is under active development; major functionality is yet to 
 be implemented and I'm sure some bugs are yet to be found.
 
-# To-do
+# Features 
+* Ethernet II 802.3 frames
+* IPV4
+* UDP
+* Optional software 
 
-* Add parser for received data
-* Add UDP psuedo-socket w/ arbitrary async send/receive functions
-* Add DHCP for autonegotiation of IP address
-* Add PTP functionality
-* Add VLAN functionality
+# To-do
+* Add UDP psuedo-socket trait w/ arbitrary async send/receive functions
+* Implement IPV6
+* Update with more general structure once const generic exprs are more stable

--- a/catnip/Cargo.toml
+++ b/catnip/Cargo.toml
@@ -15,6 +15,6 @@ panic-never = { version = "0.1.0", optional = true }
 crc32fast = { version = "1.3.2", default-features = false, optional = true }
 
 [features]
-default = ["crc"]
+default = []
 crc = ["crc32fast"]
 panic_never = ["panic-never"]

--- a/catnip/Cargo.toml
+++ b/catnip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catnip"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Minimal UDP/IP ethernet stack for use on private networks for data acquisition"
 homepage = "https://github.com/jlogan03/catnip"

--- a/catnip/Cargo.toml
+++ b/catnip/Cargo.toml
@@ -11,9 +11,10 @@ license-file = "../LICENSE"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-panic-never = "0.1.0"
+panic-never = { version = "0.1.0", optional = true }
 crc32fast = { version = "1.3.2", default-features = false, optional = true }
 
 [features]
 default = ["crc"]
 crc = ["crc32fast"]
+panic_never = ["panic-never"]

--- a/catnip/Cargo.toml
+++ b/catnip/Cargo.toml
@@ -15,4 +15,5 @@ panic-never = "0.1.0"
 crc32fast = { version = "1.3.2", default-features = false, optional = true }
 
 [features]
+default = ["crc"]
 crc = ["crc32fast"]

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -103,16 +103,16 @@ fn main() -> () {
             ) = x;
             println!(
                 "
-data: {data_parsed:?}
-options: {options_parsed:?}
-src_ipaddr: {src_ipaddr_parsed:?}
-src_port: {src_port_parsed:?}
-dst_ipaddr: {dst_ipaddr_parsed:?}
-dst_port: {dst_port_parsed:?}
-version: {version_parsed:?}
-protocol: {protocol_parsed:?}
-UDP checksum: {checksum_parsed:?}
-identification: {identification_parsed:?}
+                data: {data_parsed:?}
+                options: {options_parsed:?}
+                src_ipaddr: {src_ipaddr_parsed:?}
+                src_port: {src_port_parsed:?}
+                dst_ipaddr: {dst_ipaddr_parsed:?}
+                dst_port: {dst_port_parsed:?}
+                version: {version_parsed:?}
+                protocol: {protocol_parsed:?}
+                UDP checksum: {checksum_parsed:?}
+                identification: {identification_parsed:?}
             "
             );
             assert_eq!([0, 1, 2, 3, 4, 5, 6, 7], data_parsed);

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -1,9 +1,9 @@
 //! Build a UDP/IP Ethernet packet and get its representation as network bytes
 
 use catnip::enet::{EtherType, EthernetFrameUDP, EthernetHeader, EthernetPacketUDP};
-use catnip::ip::{IPV4Addr, IPV4Header, DSCP};
+use catnip::ip::{IPV4Header, DSCP};
 use catnip::udp::{UDPHeader, UDPPacket};
-use catnip::{Data, MACAddr};
+use catnip::{Data, IPV4Addr, MACAddr};
 extern crate std; // To show debugging output
 
 fn main() -> () {
@@ -34,11 +34,11 @@ fn main() -> () {
     // Build IP header with no Options section
     // Header length is populated in new()
     // Total length is populated by UDPPacket.finalize()
-    let ipheader: IPV4Header<0> = IPV4Header::new()
+    let mut ipheader: IPV4Header<0> = IPV4Header::new();
+    ipheader
         .src_ipaddr(src_ipaddr)
         .dst_ipaddr(dst_ipaddr)
-        .dscp(DSCP::Realtime)
-        .finalize();
+        .dscp(DSCP::Realtime);
     println!("{:?}", &ipheader);
     println!("{:?}\n", &ipheader.to_be_bytes());
 

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -1,10 +1,12 @@
 //! Build a UDP/IP Ethernet packet and get its representation as network bytes
 
-use catnip::enet::{EtherType, EthernetFrameUDP, EthernetHeader, EthernetPacketUDP};
-use catnip::ip::{IPV4Header, DSCP};
-use catnip::udp::{UDPHeader, UDPPacket};
-use catnip::{Data, IPV4Addr, MACAddr};
-extern crate std; // To show debugging output
+use catnip::enet::{
+    parse_header_bytes, EtherType, EthernetFrameUDP, EthernetHeader, EthernetPacketUDP,
+};
+use catnip::ip::IPV4Header;
+use catnip::udp::{parse_packet_bytes, UDPHeader, UDPPacket};
+use catnip::{Data, IPV4Addr, MACAddr, Version, DSCP};
+// extern crate std; // To show debugging output
 
 fn main() -> () {
     // Some made-up addresses
@@ -38,6 +40,8 @@ fn main() -> () {
     ipheader
         .src_ipaddr(src_ipaddr)
         .dst_ipaddr(dst_ipaddr)
+        .version(Version::V4)
+        .ttl(100)
         .dscp(DSCP::Realtime);
     println!("{:?}", &ipheader);
     println!("{:?}\n", &ipheader.to_be_bytes());
@@ -48,13 +52,10 @@ fn main() -> () {
     println!("{:?}\n", &udpheader.to_be_bytes());
 
     // Build UDP packet with 0 words of IP options and 2 words of data
-    let udppacket: UDPPacket<0, 2> = UDPPacket {
-        ip_header: ipheader,
-        udp_header: udpheader,
-        udp_data: data,
-    }; // Populates packet length fields for both IP and UDP headers
+    let udppacket: UDPPacket<0, 2> = UDPPacket::new(ipheader, udpheader, data); // Populates packet length fields for both IP and UDP headers
+    let udp_packet_bytes = udppacket.to_be_bytes();
     println!("{:?}", &udppacket);
-    println!("{:?}\n", &udppacket.to_be_bytes());
+    println!("{:?}\n", &udp_packet_bytes);
 
     // Build Ethernet frame header
     let enetheader: EthernetHeader = EthernetHeader::new(src_macaddr, dst_macaddr, EtherType::IPV4);
@@ -64,11 +65,59 @@ fn main() -> () {
     // Build Ethernet frame
     // Unfortunately these can't be generic until const generic expr trait bounds work
     let enetframe = EthernetFrameUDP::new(enetheader, udppacket);
+    let enet_frame_bytes = &enetframe.to_be_bytes();
     println!("{:?}", &enetframe);
-    println!("{:?}\n", &enetframe.to_be_bytes());
+    println!("{:?}\n", enet_frame_bytes);
 
     // Build Ethernet packet
     let enetpacket = EthernetPacketUDP::new(enetframe);
     println!("{:?}", &enetpacket);
     println!("{:?}\n", &enetpacket.to_be_bytes());
+
+    // Test parsing
+    //    Ethernet header
+    let mut enet_header_bytes = [0_u8; 14];
+    enet_header_bytes.copy_from_slice(&enet_frame_bytes[0..14]);
+    let (src_macaddr_parsed, dst_macaddr_parsed, ethertype_parsed) =
+        parse_header_bytes(&enet_header_bytes);
+    assert_eq!(src_macaddr.value, src_macaddr_parsed.value);
+    assert_eq!([0xFF_u8; 6], dst_macaddr_parsed.value);
+    assert_eq!(EtherType::IPV4 as u32, ethertype_parsed as u32);
+    //    UDP packet
+    let mut header_bytes = [0_u8; 20];
+    header_bytes.copy_from_slice(&udp_packet_bytes[0..20]);
+
+    match parse_packet_bytes(&udp_packet_bytes) {
+        Ok(x) => {
+            let (
+                data_parsed,
+                options_parsed,
+                src_ipaddr_parsed,
+                src_port_parsed,
+                dst_ipaddr_parsed,
+                dst_port_parsed,
+                version_parsed,
+                protocol_parsed,
+                checksum_parsed,
+                identification_parsed,
+            ) = x;
+            println!(
+                "
+data: {data_parsed:?}
+options: {options_parsed:?}
+src_ipaddr: {src_ipaddr_parsed:?}
+src_port: {src_port_parsed:?}
+dst_ipaddr: {dst_ipaddr_parsed:?}
+dst_port: {dst_port_parsed:?}
+version: {version_parsed:?}
+protocol: {protocol_parsed:?}
+checksum: {checksum_parsed:?}
+identification: {identification_parsed:?}
+            "
+            );
+        }
+        Err(x) => {
+            println!("Failed to parse UDP packet: {x}")
+        }
+    }
 }

--- a/catnip/examples/packet.rs
+++ b/catnip/examples/packet.rs
@@ -5,7 +5,7 @@ use catnip::enet::{
 };
 use catnip::ip::IPV4Header;
 use catnip::udp::{parse_packet_bytes, UDPHeader, UDPPacket};
-use catnip::{Data, IPV4Addr, MACAddr, Version, DSCP};
+use catnip::{Data, IPV4Addr, MACAddr, Version, DSCP, Protocol};
 // extern crate std; // To show debugging output
 
 fn main() -> () {
@@ -111,10 +111,20 @@ dst_ipaddr: {dst_ipaddr_parsed:?}
 dst_port: {dst_port_parsed:?}
 version: {version_parsed:?}
 protocol: {protocol_parsed:?}
-checksum: {checksum_parsed:?}
+UDP checksum: {checksum_parsed:?}
 identification: {identification_parsed:?}
             "
             );
+            assert_eq!([0, 1, 2, 3, 4, 5, 6, 7], data_parsed);
+            assert_eq!([0_u8; 0], options_parsed);
+            assert_eq!(src_ipaddr.value, src_ipaddr_parsed.value);
+            assert_eq!(src_port, src_port_parsed);
+            assert_eq!(dst_ipaddr.value, dst_ipaddr_parsed.value);
+            assert_eq!(dst_port, dst_port_parsed);
+            assert_eq!(Version::V4 as u8, version_parsed as u8);
+            assert_eq!(Protocol::UDP as u8, protocol_parsed as u8);
+            assert_eq!(0, checksum_parsed);
+            assert_eq!(0, identification_parsed);
         }
         Err(x) => {
             println!("Failed to parse UDP packet: {x}")

--- a/catnip/src/enet.rs
+++ b/catnip/src/enet.rs
@@ -4,7 +4,9 @@
 
 use crate::{udp::UDPPacket, MACAddr};
 
-/// Combined preamble and start-frame delimiter because they are never changed or separated
+/// Combined 7-byte preamble and 1-byte start-frame delimiter because they are never changed or separated
+/// 
+/// These are usually supplied by the hardware
 const PREAMBLE: [u8; 8] = [
     0b1010_1010,
     0b1010_1010,
@@ -17,6 +19,8 @@ const PREAMBLE: [u8; 8] = [
 ];
 
 /// Standard 96-bit inter-packet gap
+/// 
+/// This is usually supplied by the hardware
 const IPG: [u8; 12] = [0; 12];
 
 /// Header for Ethernet II frame like
@@ -101,6 +105,32 @@ impl EthernetHeader {
     pub fn to_be_bytes(&self) -> [u8; 14] {
         self.value
     }
+
+    /// Parse fields from bytes
+    pub fn from_be_bytes(bytes: [u8; 14]) -> (MACAddr, MACAddr, EtherType) {
+        use EtherType::*;
+
+        let mut src_macaddr = MACAddr{value: [0_u8; 6]};
+        src_macaddr.value.copy_from_slice(&bytes[0..6]);
+
+        let mut dst_macaddr = MACAddr{value: [0_u8; 6]};
+        dst_macaddr.value.copy_from_slice(&bytes[5..11]);
+
+        let mut ethertype_bytes = [0_u8; 2];
+        ethertype_bytes.copy_from_slice(&bytes[10..12]);
+        let ethertype_int = u16::from_be_bytes(ethertype_bytes);
+        let ethertype = match ethertype_int {
+            x if x == (IPV4 as u16) => IPV4,
+            x if x == (ARP as u16) => ARP,
+            x if x == (VLAN as u16) => VLAN,
+            x if x == (IPV6 as u16) => IPV6,
+            x if x == (EtherCat as u16) => EtherCat,
+            x if x == (PTP as u16) => PTP,
+            _ => Unimplemented
+        };
+
+        return (src_macaddr, dst_macaddr, ethertype)
+    }
 }
 
 /// Ethernet II frame (variable parts of a packet)
@@ -162,6 +192,12 @@ where
 }
 
 /// Ethernet II packet (including preamble, start-frame delimiter, and interpacket gap)
+/// 
+/// A hardware MAC usually takes the frame as an input and builds a packet from it, so
+/// 
+/// this exercise of building the actual packet from a frame is somewhat academic, but useful for testing
+/// 
+/// and for estimating network utilization
 #[derive(Clone, Debug)]
 pub struct EthernetPacketUDP<const N: usize, const M: usize>
 where
@@ -196,7 +232,7 @@ where
     /// Calculate ethernet checksum in software
     #[cfg(feature = "crc")]
     pub fn calc_enet_checksum(&self, frame_bytes: &[u8; (4 * N + 20) + (4 * M) + 14 + 8]) -> u32 {
-        let checksum: u32 = crc32fast::hash(&frame_bytes);
+        let checksum: u32 = crc32fast::hash(frame_bytes);
         checksum
     }
 
@@ -250,6 +286,7 @@ where
 ///
 /// See https://en.wikipedia.org/wiki/EtherType
 #[derive(Clone, Copy, Debug)]
+#[repr(u16)]
 pub enum EtherType {
     /// IPV4
     IPV4 = 0x0800,
@@ -263,4 +300,6 @@ pub enum EtherType {
     EtherCat = 0x88A4,
     /// Precision Time Protocol
     PTP = 0x88A7,
+    /// Catch-all for uncommon types not handled here
+    Unimplemented = 0
 }

--- a/catnip/src/enet.rs
+++ b/catnip/src/enet.rs
@@ -73,7 +73,7 @@ impl EthernetHeader {
     /// Set destination mac address
     pub fn dst_macaddr(&mut self, v: &[u8; 6]) -> &mut Self {
         for i in 0..6 {
-            self.value[i + 5] = v[i];
+            self.value[i + 6] = v[i];
         }
 
         self
@@ -109,17 +109,17 @@ impl EthernetHeader {
 
 
 /// Parse fields from bytes
-pub fn parse_header_bytes(bytes: [u8; 14]) -> (MACAddr, MACAddr, EtherType) {
+pub fn parse_header_bytes(bytes: &[u8; 14]) -> (MACAddr, MACAddr, EtherType) {
     use EtherType::*;
 
     let mut src_macaddr = MACAddr{value: [0_u8; 6]};
     src_macaddr.value.copy_from_slice(&bytes[0..6]);
 
     let mut dst_macaddr = MACAddr{value: [0_u8; 6]};
-    dst_macaddr.value.copy_from_slice(&bytes[5..11]);
+    dst_macaddr.value.copy_from_slice(&bytes[6..12]);
 
     let mut ethertype_bytes = [0_u8; 2];
-    ethertype_bytes.copy_from_slice(&bytes[10..12]);
+    ethertype_bytes.copy_from_slice(&bytes[12..14]);
     let ethertype_int = u16::from_be_bytes(ethertype_bytes);
     let ethertype = match ethertype_int {
         x if x == (IPV4 as u16) => IPV4,

--- a/catnip/src/enet.rs
+++ b/catnip/src/enet.rs
@@ -1,8 +1,11 @@
-//! Ethernet II protocol per IEEE 802.3
+//! Link layer: Ethernet II protocol per IEEE 802.3
 //! 
 //! Diagram at https://en.wikipedia.org/wiki/Ethernet_frame#Ethernet_II
 
 use crate::{udp::UDPPacket, MACAddr};
+
+#[cfg(feature = "crc")]
+use crc32fast;
 
 /// Combined 7-byte preamble and 1-byte start-frame delimiter because they are never changed or separated
 /// 

--- a/catnip/src/enet.rs
+++ b/catnip/src/enet.rs
@@ -1,4 +1,5 @@
 //! Ethernet II protocol per IEEE 802.3
+//! 
 //! Diagram at https://en.wikipedia.org/wiki/Ethernet_frame#Ethernet_II
 
 use crate::{udp::UDPPacket, MACAddr};
@@ -212,8 +213,7 @@ where
         let mut bytes = [0_u8; 4 * N + 20 + 4 * M + 14 + 8 + 24];
 
         // Calculate CRC32 checksum over ethernet frame
-        // TODO: this could be done faster using either a persistent Hasher
-        // or a CRC32 peripheral
+        // TODO: this could be done faster using a persistent Hasher
         let frame_bytes = self.frame.to_be_bytes();
         let checksum: u32 = self.calc_enet_checksum(&frame_bytes);
         let checksum_bytes: [u8; 4] = checksum.to_be_bytes();

--- a/catnip/src/enet.rs
+++ b/catnip/src/enet.rs
@@ -107,7 +107,7 @@ impl EthernetHeader {
     }
 
     /// Parse fields from bytes
-    pub fn from_be_bytes(bytes: [u8; 14]) -> (MACAddr, MACAddr, EtherType) {
+    pub fn parse_be_bytes(bytes: [u8; 14]) -> (MACAddr, MACAddr, EtherType) {
         use EtherType::*;
 
         let mut src_macaddr = MACAddr{value: [0_u8; 6]};
@@ -275,8 +275,6 @@ where
             bytes[i] = v;
             i = i + 1;
         }
-
-        // assert_eq!(i, bytes.len());
 
         bytes
     }

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -1,5 +1,6 @@
 //! Internet Protocol message header construction
 
+
 use crate::{calc_ip_checksum, IPV4Addr};
 
 /// IPV4 header per IETF-RFC-791
@@ -37,10 +38,9 @@ use crate::{calc_ip_checksum, IPV4Addr};
 /// value [16:19] Destination IP Address
 ///
 /// N is number of 32-bit words to reserve for the Options section
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct IPV4Header<const N: usize>
-where
-    [u8; 4 * N + 20]:,
+where [u8; 4 * N + 20]:,
 {
     /// The actual content of the header as bytes
     pub value: [u8; 4 * N + 20],
@@ -53,20 +53,14 @@ where
     /// Start from some sensible defaults
     pub fn new() -> Self {
         // Start a blank header and apply some sensible defaults
-        let header = IPV4Header { value: [0_u8; 4 * N + 20] }
-            .version(Version::V4)
+        let mut header = IPV4Header { value: [0_u8; 4 * N + 20] };
+        header.version(Version::V4)
             .header_length({ 5 + N } as u8)
             .dscp(DSCP::Standard)
             .ttl(100)
-            .protocol(Protocol::UDP)
-            .finalize();
+            .protocol(Protocol::UDP);
 
         header
-    }
-
-    /// Dereference to prevent droppage
-    pub fn finalize(&mut self) -> Self {
-        *self
     }
 
     /// Set version

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -1,6 +1,6 @@
 //! Internet Protocol message header construction
 
-use crate::{calc_ip_checksum};
+use crate::{calc_ip_checksum, IPV4Addr};
 
 /// IPV4 header per IETF-RFC-791
 ///
@@ -250,16 +250,12 @@ where
     }
 }
 
-/// IPV4 Address as bytes
-#[derive(Clone, Copy, Debug)]
-pub struct IPV4Addr {
-    /// 4-byte IP address
-    pub value: [u8; 4],
-}
-
 /// Common choices of transport-layer protocols
+/// 
 /// and their IP header values.
+/// 
 /// There are many more protocols not listed here -
+/// 
 /// see https://en.wikipedia.org/wiki/List_of_IP_protocol_numbers
 #[derive(Clone, Copy, Debug)]
 pub enum Protocol {
@@ -279,6 +275,7 @@ pub enum Version {
 }
 
 /// https://en.wikipedia.org/wiki/Differentiated_services
+/// 
 /// Priority 2 is low-latency class
 #[derive(Clone, Copy, Debug)]
 pub enum DSCP {

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -1,8 +1,10 @@
-//! Internet Protocol message header construction
+//! Internet layer: Internet Protocol message header construction
 
 use crate::{calc_ip_checksum, IPV4Addr};
 
 /// IPV4 header per IETF-RFC-791
+/// 
+/// N is number of 32-bit words to reserve for the Options section
 ///
 /// https://en.wikipedia.org/wiki/IPv4
 ///
@@ -35,8 +37,6 @@ use crate::{calc_ip_checksum, IPV4Addr};
 /// fifth 32-bit word
 ///
 /// value [16:19] Destination IP Address
-///
-/// N is number of 32-bit words to reserve for the Options section
 #[derive(Clone, Debug)]
 pub struct IPV4Header<const N: usize>
 where

--- a/catnip/src/ip.rs
+++ b/catnip/src/ip.rs
@@ -235,56 +235,56 @@ where
     pub fn to_be_bytes(&self) -> [u8; 4 * N + 20] {
         self.value
     }
+}
 
-    /// Parse (some) fields from big-endian (network) byte array
-    pub fn parse_be_bytes(
-        bytes: &[u8; 4 * N + 20],
-    ) -> (Version, Protocol, IPV4Addr, IPV4Addr, u8, u16, [u8; 4 * N]) {
-        let version = match bytes[0] | 0b0000_1111 {
-            4 => Version::V4,
-            6 => Version::V6,
-            _ => Version::V4, // Default to IPV4 if the version field is invalid
-        };
+/// Parse (some) fields from big-endian (network) byte array
+pub fn parse_be_bytes<const N: usize>(
+    bytes: &[u8; 4 * N + 20],
+) -> (Version, Protocol, IPV4Addr, IPV4Addr, u8, u16, [u8; 4 * N]) {
+    let version = match bytes[0] | 0b0000_1111 {
+        4 => Version::V4,
+        6 => Version::V6,
+        _ => Version::V4, // Default to IPV4 if the version field is invalid
+    };
 
-        let header_length: u8 = bytes[0] & 0b0000_1111;
+    let header_length: u8 = bytes[0] & 0b0000_1111;
 
-        let mut total_length_bytes = [0_u8; 2];
-        total_length_bytes.copy_from_slice(&bytes[2..4]);
-        let total_length: u16 = u16::from_be_bytes(total_length_bytes);
+    let mut total_length_bytes = [0_u8; 2];
+    total_length_bytes.copy_from_slice(&bytes[2..4]);
+    let total_length: u16 = u16::from_be_bytes(total_length_bytes);
 
-        let mut src_ipaddr_bytes = [0_u8; 4];
-        src_ipaddr_bytes.copy_from_slice(&bytes[12..16]);
-        let src_ipaddr = IPV4Addr {
-            value: src_ipaddr_bytes,
-        };
+    let mut src_ipaddr_bytes = [0_u8; 4];
+    src_ipaddr_bytes.copy_from_slice(&bytes[12..16]);
+    let src_ipaddr = IPV4Addr {
+        value: src_ipaddr_bytes,
+    };
 
-        let mut dst_ipaddr_bytes = [0_u8; 4];
-        dst_ipaddr_bytes.copy_from_slice(&bytes[16..20]);
-        let dst_ipaddr = IPV4Addr {
-            value: dst_ipaddr_bytes,
-        };
+    let mut dst_ipaddr_bytes = [0_u8; 4];
+    dst_ipaddr_bytes.copy_from_slice(&bytes[16..20]);
+    let dst_ipaddr = IPV4Addr {
+        value: dst_ipaddr_bytes,
+    };
 
-        let protocol = match bytes[9] {
-            x if x == Protocol::TCP as u8 => Protocol::TCP,
-            x if x == Protocol::UDP as u8 => Protocol::UDP,
-            _ => Protocol::Unimplemented,
-        };
+    let protocol = match bytes[9] {
+        x if x == Protocol::TCP as u8 => Protocol::TCP,
+        x if x == Protocol::UDP as u8 => Protocol::UDP,
+        _ => Protocol::Unimplemented,
+    };
 
-        let mut options = [0_u8; 4 * N];
-        if N > 0 {
-            options.copy_from_slice(&bytes[20..4 * N + 20]);
-        }
-
-        return (
-            version,
-            protocol,
-            src_ipaddr,
-            dst_ipaddr,
-            header_length,
-            total_length,
-            options,
-        );
+    let mut options = [0_u8; 4 * N];
+    if N > 0 {
+        options.copy_from_slice(&bytes[20..4 * N + 20]);
     }
+
+    return (
+        version,
+        protocol,
+        src_ipaddr,
+        dst_ipaddr,
+        header_length,
+        total_length,
+        options,
+    );
 }
 
 /// Common choices of transport-layer protocols

--- a/catnip/src/lib.rs
+++ b/catnip/src/lib.rs
@@ -6,12 +6,15 @@
 #![feature(generic_const_exprs)]
 #![feature(test)]
 
-#[cfg(release)]
-extern crate panic_never;
+#[cfg(feature = "panic_never")]
+use panic_never as _;
 
 pub mod enet; // Link Layer
 pub mod ip; // Internet layer
 pub mod udp; // Transport layer
+
+pub use enet::EtherType;
+pub use ip::{Version, Protocol, DSCP, Flags};
 
 // All protocols' headers, data, and frames must be able to convert to byte array
 // in order to be consumed by EMAC/PHY drivers for transmission

--- a/catnip/src/lib.rs
+++ b/catnip/src/lib.rs
@@ -45,7 +45,7 @@ pub struct IPV4Addr {
 }
 
 /// IP and UDP require their data to be a multiple of 4 bytes (32-bit words)
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[repr(transparent)]
 pub struct Data<const Q: usize> where [u8; 4 * Q]:, {
     /// Byte array of data
@@ -66,6 +66,7 @@ impl<const Q: usize> Data<Q> where [u8; 4 * Q]:,  {
         self.value
     }
 }
+
 
 /// Calculate IP checksum per IETF-RFC-768
 /// 
@@ -116,8 +117,8 @@ pub fn calc_ip_checksum(data: &[u8]) -> u16 {
 #[cfg(test)]
 mod tests {
 
-    #[macro_use]
     extern crate std;
+    use std::println;
 
     use crate::{calc_ip_checksum, ip::IPV4Header};
 
@@ -162,7 +163,7 @@ mod tests {
             0x0a63_u16, 0xac10_u16, 0x0a0c_u16, 0x0F00_u16, 0_u16,
         ];
         let mut header: IPV4Header<1> = IPV4Header::<1>::from_16bit_words(&ipheader_16_extended);
-        header = header.header_checksum().finalize(); // Apply checksum value
+        header.header_checksum(); // Apply checksum value
         let cyclic_check = calc_ip_checksum(&header.value);
         assert_eq!(cyclic_check, 0_u16);
     }

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -144,35 +144,3 @@ where
         bytes
     }
 }
-
-
-#[cfg(test)]
-mod test {
-    // use super::{UDPHeader, UDPPacket};
-
-    // #[test]
-    // fn test_udp_header() {
-    //     // Parse and replicate example header from https://www.khanacademy.org/computing/computers-and-internet/xcae6f4a7ff015e7d:the-internet/xcae6f4a7ff015e7d:transporting-packets/a/user-datagram-protocol-udp
-    //     let example_header: [u16; 4] = [
-    //         0b00010101_00001001,
-    //         0b0001010_100001001,
-    //         0b00000000_00000100,
-    //         0b10110100_11010000,
-    //     ];
-    //     let example_data: [u8; 4] = [0b01001000, 0b01101111, 0b01101100, 0b01100001];
-    //     // let mut example_u16: [u16; 4] = [0_u16; 4];
-    //     // for i in 0..4 {
-    //     //     let bytes: [u8; 2] = [example_bytes[2*i], example_bytes[2*i + 1]];
-    //     //     example_u16[i] = u16::from_be_bytes(bytes);
-    //     // }
-    //     let example_header: UDPHeader = UDPHeader {
-    //         value: example_header,
-    //     };
-    //     let example_packet: UDPPacket<0, 1> = UDPPacket {
-    //         ip_header: crate::ip::IPV4Header::new(),
-    //         udp_header: example_header,
-    //         udp_data: example_data,
-    //     };
-
-    // }
-}

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -1,4 +1,4 @@
-//! User Datagram Protocol
+//! Transport layer: User Datagram Protocol
 
 use crate::ip::{self, IPV4Header, Protocol, Version};
 use crate::{calc_ip_checksum, Data, IPV4Addr};

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -52,12 +52,22 @@ impl UDPHeader {
     }
 }
 
+/// Parse a UDP header from bytes
+pub fn parse_header_bytes(bytes: &[u8; 8]) -> (u16, u16, u16, u16) {
+    let src_port = u16::from_be_bytes([bytes[0], bytes[1]]);
+    let dst_port = u16::from_be_bytes([bytes[2], bytes[3]]);
+    let total_length = u16::from_be_bytes([bytes[4], bytes[5]]);
+    let checksum = u16::from_be_bytes([bytes[6], bytes[7]]);
 
-/// IP message frame for UDP protocol
+    (src_port, dst_port, total_length, checksum)
+}
+
+
+/// IPV4 message frame for UDP protocol.
 ///
-/// N is size of IP Options in 32-bit words
+/// N is size of IP Options in 32-bit words.
 ///
-/// M is size of UDP Data in 32-bit words
+/// M is size of UDP Data in 32-bit words.
 #[derive(Clone, Debug)]
 pub struct UDPPacket<const N: usize, const M: usize>
 where
@@ -80,11 +90,11 @@ where
     [u8; 4 * N + 20 + 4 * M + 8]:, // Required for Transportable trait
     // UDPPacket<'a, N, M>: Transportable<{ 4 * N + 20 + 4 * M + 8 }>,
 {
-    /// Build a UDP packet and populate the components that depend on the combined data
+    /// Build a UDP packet and populate the components that depend on the combined data.
     ///
-    /// N is size of IP Options in 32-bit words
+    /// N is size of IP Options in 32-bit words.
     ///
-    /// M is size of UDP Data in 32-bit words
+    /// M is size of UDP Data in 32-bit words.
     pub fn new(
         ip_header: IPV4Header<N>,
         udp_header: UDPHeader,
@@ -147,3 +157,12 @@ where
         bytes
     }
 }
+
+// Attempt to parse UDP packet components from bytes
+// pub fn parse_packet_bytes(bytes: &[u8]) {
+//     let p = bytes.len();
+//     let mut 
+//     if p > 20 {
+        
+//     }
+// }

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -1,5 +1,7 @@
 //! User Datagram Protocol
 
+#![feature(generic_const_exprs)]
+
 use crate::ip::IPV4Header;
 use crate::{calc_ip_checksum, Data};
 
@@ -56,11 +58,12 @@ impl UDPHeader {
 /// N is size of IP Options in 32-bit words
 ///
 /// M is size of UDP Data in 32-bit words
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct UDPPacket<const N: usize, const M: usize>
 where
-    [u8; 4 * N + 20]:,
+    // [u8; 4 * N + 20]:,
     [u8; 4 * M]:,
+    [u8; 4 * N + 20]:,
 {
     /// IPV4 packet header
     pub ip_header: IPV4Header<N>,
@@ -107,7 +110,7 @@ where
 
         // Set UDP packet length in bytes
         udppacket.udp_header.value[2] =
-            (udp_data.len() + udp_header.len()) as u16;
+            (&udppacket.udp_data.len() + udp_header.len()) as u16;
 
         // Zero-out UDP checksum because it is redundant with ethernet checksum & prone to overflow
         udppacket.udp_header.value[3] = 0;

--- a/catnip/src/udp.rs
+++ b/catnip/src/udp.rs
@@ -240,7 +240,7 @@ pub fn parse_packet_bytes(
     let (src_port, dst_port, _, checksum) = parse_header_bytes(&header_bytes);
 
     // Extract UDP data
-    let data = &bytes[9..];
+    let data = &bytes[8..];
 
     Ok((
         data, options, src_ipaddr, src_port, dst_ipaddr, dst_port, version, protocol, checksum, identification


### PR DESCRIPTION
* Implement parsing capability for IPV4 UDP frames and Ethernet II headers, compatible with panic-never
* Eliminate Copy derives for const generic parametrized structs, as this now breaks the compiler
* Rework to use core::ptr instead of Volatile & eliminate dependency on Volatile
* Add feature configuration for software CRC calculation and use of panic-never